### PR TITLE
Sbt Logger interface

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,11 +7,16 @@ All notable changes to this project will be documented in this file.
 
 * `all` assertion as an alternative to chaining many `and`s together.
 * Basic scalacheck support
+* SBT logging suport
 
 === Fixed
 
 * SBT plugin name & Conventions
 * SBT test interface now fails the build and works with `testQuick`
+
+== Changed
+
+* Observers for tests and runs are now in a `RunConfiguration` object
 
 == [0.2.0] - 2019-09-23
 

--- a/README.adoc
+++ b/README.adoc
@@ -135,6 +135,7 @@ An example of a test entry point:
 ----
 import io.github.olib963.javatest.*;
 import io.github.olib963.javatest.fixtures.Fixtures;
+import io.github.olib963.javatest.javafire.TestRunners;
 
 import java.util.Collection;
 import java.util.List;
@@ -545,6 +546,7 @@ package my.awesome.app;
 
 import io.github.olib963.javatest.*;
 import io.github.olib963.javatest.fixtures.Fixtures;
+import io.github.olib963.javatest.javafire.TestRunners;
 
 import java.util.Collection;
 import java.util.List;

--- a/README.adoc
+++ b/README.adoc
@@ -21,8 +21,8 @@ therefore JavaTest only introduces a few new functions and types to the language
 * Instead of being *Annotation* and *Exception* driven, JavaTest is *Function* and *Value* driven,
 lending itself to composability of tests and assertions.
 
-* JavaTests contains no reflection magic. A more declarative approach to testing is taken where setting up and customising tests is left
-to the writer.
+* JavaTests contains no reflection magic by default. A more declarative approach to testing is taken where setting up and
+customising tests is up to the writer.
 
 * A test should ideally only test one thing and should certainly test _at least_ one thing. Since
 all tests must return an assertion value the compiler will enforce that all tests only test one result.
@@ -356,7 +356,7 @@ public class ClassAsSuite implements TestSuiteClass {
 
 ==== Suite Nesting
 
-``TestSuite``s contain ``Testable``s not ``Test``s and thus can even be contain other ``TestSuite``s.
+``TestSuite``s contain ``Testable``s not ``Test``s and thus can contain other ``TestSuite``s.
 
 [source, java]
 ----
@@ -415,7 +415,7 @@ public class MyPendingTests implements TestSuiteClass {
 The main `TestRunner` included in the core is created from a `Collection<Testable>`. You can optionally add a collection of
 ``TestCompletionObserver``s to the runner, by default a logging observer is passed that logs each test result with a colour
 corresponding to the state of the test (green for passing, red for failing and yellow for pending). If you want to turn off
-logging just pass an empty collection, a `TestCompletionObserver.plainLogger` also exists that uses no colours.
+logging just pass an empty collection. A `TestCompletionObserver.plainLogger` also exists that uses no colours.
 
 [source, java]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -622,6 +622,59 @@ In `pom.xml`:
 
 You can override the `testRunners` class being used by setting the maven property e.g. `mvn -Djavafire.testRunners=com.my.app.OtherTests test`.
 
+==== Run Configuration
+
+You can provide your own `RunConfiguration` class within the plugin configuration. If you create a class with a *public zero argument constructor*
+that implements `RunConfigurationProvider` such as:
+
+[source, java]
+----
+package my.awesome.app;
+
+import io.github.olib963.javatest.RunConfiguration;
+import io.github.olib963.javatest.TestCompletionObserver;
+import io.github.olib963.javatest.TestResult;
+import io.github.olib963.javatest.TestRunCompletionObserver;
+import io.github.olib963.javatest.javafire.RunConfigurationProvider;
+
+/**
+ * My config provider only logs failed tests and the full run results
+ */
+public class MyConfigProvider implements RunConfigurationProvider {
+
+    @Override
+    public RunConfiguration config() {
+        var loggingObserver = TestCompletionObserver.colourLogger();
+        TestCompletionObserver onlyLogFailures = result -> {
+            if(testFailed(result)) {
+                loggingObserver.onTestCompletion(result);
+            }
+        };
+        return RunConfiguration.empty()
+                .addRunObserver(TestRunCompletionObserver.logger())
+                .addTestObserver(onlyLogFailures);
+    }
+
+    private boolean testFailed(TestResult result) {
+        return result.match(
+                suiteResult -> suiteResult.results().anyMatch(this::testFailed),
+                singleTestResult -> !singleTestResult.result.holds
+        );
+    }
+}
+----
+
+then you can set the configuration option in the plugin:
+
+[source, xml]
+----
+ <configuration>
+    <runConfigurationProvider>my.awesome.app.MyConfigProvider</runConfigurationProvider>
+</configuration>
+----
+
+You can also override the provider class on the commandline by setting the maven property e.g. `mvn -Djavafire.runConfigurationProvider=com.my.app.ConfigProvider test`.
+
 === JShell
 
 Since JavaTest is built on pure Java it plays quite nicely with the REPL. This startup script may be useful to you:

--- a/README.adoc
+++ b/README.adoc
@@ -223,6 +223,8 @@ toc::[]
 ** `TestSuite`: a named logical collection of ``Testable``s
 * `Assertion`: represents the expected state at the end of a test
 * `TestResults`: represents the combined result of your tests
+* `RunConfiguration`: An object that contains configuration for a specific run of JavaTest. Currently this just contains
+side-effecting observers.
 
 === Creating Assertions
 
@@ -413,10 +415,7 @@ public class MyPendingTests implements TestSuiteClass {
 
 === Test Runners
 
-The main `TestRunner` included in the core is created from a `Collection<Testable>`. You can optionally add a collection of
-``TestCompletionObserver``s to the runner, by default a logging observer is passed that logs each test result with a colour
-corresponding to the state of the test (green for passing, red for failing and yellow for pending). If you want to turn off
-logging just pass an empty collection. A `TestCompletionObserver.plainLogger` also exists that uses no colours.
+The main `TestRunner` included in the core is created from a `Collection<Testable>`.
 
 [source, java]
 ----
@@ -431,20 +430,17 @@ public class MyRunners {
     public TestRunner singleTestRunner = testableRunner(List.of(
             test("Simple test", () -> pending())));
 
-    public TestRunner suiteTestsNoLogging = testableRunner(
-            List.of(MyFirstTestSuite.mySuite(), new ClassAsSuite()),
-            Collections.emptyList() // No observers so no logging
+    public TestRunner suiteTests = testableRunner(
+            List.of(MyFirstTestSuite.mySuite(), new ClassAsSuite())
     );
 }
 ----
 
-Other `TestRunner` implementations are available in the other modules.
-
 ==== Laziness
 
-It is possible to create a lazy test runner from a `Stream<Testable>` also with optional collection of ``TestCompletionObserver``s.
-This runner however is not referentially transparent or reusable so must be used with care. This might be useful if you have
-a very large collection of tests and you want to lazily instantiate the different suites.
+It is possible to create a lazy test runner from a `Stream<Testable>`. This runner however is not referentially transparent
+or reusable so must be used with care. This might be useful if you have a very large collection of tests and you want
+to lazily instantiate the different suites.
 
 [source, java]
 ----
@@ -460,6 +456,37 @@ public class LazyRunners {
 
     public TestRunner lazyRunner = lazyTestableRunner(oneHundredLazyTests);
 
+}
+----
+
+Other `TestRunner` implementations are available in the other modules.
+
+=== Run Configuration
+
+You can optionally add a collection of ``TestCompletionObserver``s and ``TestRunCompletionObserver``s to the run of JavaTest.
+By default a logging observer is passed that logs each test result with a colour corresponding to the state of the test
+(green for passing, red for failing and yellow for pending) and a logging observer for the completion of the run that logs
+the total failed, passing and pending results.
+
+[source, java]
+----
+import io.github.olib963.javatest.RunConfiguration;
+import io.github.olib963.javatest.TestCompletionObserver;
+
+public class RunConfigurations {
+
+    // Configuration that logs individual tests in colour and the full results of the run
+    public RunConfiguration defaultConfig = RunConfiguration.defaultConfig();
+
+    // Configuration that logs individual tests with no colour and logs a warning
+    // if there are any pending tests at all in the run.
+    public RunConfiguration customConfig = RunConfiguration.empty()
+            .addTestObserver(TestCompletionObserver.plainLogger())
+            .addRunObserver(results -> {
+                if (results.pendingCount != 0) {
+                    System.err.println("!!You still have unwritten tests!!");
+                }
+            });
 }
 ----
 
@@ -479,8 +506,8 @@ public class LazyRunners {
 
 === In Java
 
-To run JavaTest simply pass your `TestRunner` instances to the `JavaTest.run()` function and handle the
-result how you see fit. There is a convenience function `runTests` defined to just run a `Collection<Testable>` using the default `CollectionRunner`:
+To run JavaTest simply pass your `TestRunner` instances to the `JavaTest.run()` function and handle the result how you see fit.
+There is a convenience function `runTests` defined to just run a `Collection<Testable>` using the default `CollectionRunner`:
 
 [source, java]
 ----
@@ -507,12 +534,6 @@ public class MyEntrypoint {
     }
 }
 ----
-
-==== Observer
-
-There is an interface `TestRunCompletionObserver` that exists to allow side effects to be invoked after the run has completed.
-By default the total counts of tests run will be logged to `System.out`. If you want to turn off logging simply pass an empty
-collection of observers to the `run` function i.e. `JavaTest.run(runners, Collections.emptyList())`.
 
 === With JavaFire Maven plugin
 
@@ -748,7 +769,7 @@ import java.util.Set;
 
 public class FunctionalRunners {
     // The simplest test runner: runs nothing and returns no results
-    public static final TestRunner EMPTY_RUNNER = TestResults::empty;
+    public static final TestRunner EMPTY_RUNNER = config -> TestResults.empty();
 
     private static final Set<DayOfWeek> WEEKEND =
             Set.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY);
@@ -756,8 +777,8 @@ public class FunctionalRunners {
     // Wrap another test runner such that it will not run anything on the weekend
     public TestRunner onlyRunOnWeekDays(TestRunner runner) {
         var today = LocalDate.now();
-        return () -> WEEKEND.contains(today.getDayOfWeek()) ?
-                EMPTY_RUNNER.run() : runner.run();
+        return config -> WEEKEND.contains(today.getDayOfWeek()) ?
+                EMPTY_RUNNER.run(config) : runner.run(config);
     }
 }
 ----

--- a/javafire/src/main/java/io/github/olib963/javatest/javafire/JavaTestMojo.java
+++ b/javafire/src/main/java/io/github/olib963/javatest/javafire/JavaTestMojo.java
@@ -24,9 +24,19 @@ public class JavaTestMojo extends AbstractMojo {
 	@Parameter(property = "javafire.testRunners")
 	private String testRunners;
 
+	/**
+	 * The name of the class that implements RunConfigurationProvider, providing the configuration for the test run
+	 */
+	@Parameter(property = "javafire.runConfigurationProvider")
+	private String runConfigurationProvider;
+
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
-		var testRunner = new JavaTestRunner(Optional.ofNullable(testRunners), Optional.empty(), new ThreadLocalClassLoaderProvider(), lookupProject());
+		var testRunner = new JavaTestRunner(
+				Optional.ofNullable(testRunners),
+				Optional.ofNullable(runConfigurationProvider),
+				new ThreadLocalClassLoaderProvider(),
+				lookupProject());
 		validateResult(testRunner.run());
 	}
 

--- a/javafire/src/main/java/io/github/olib963/javatest/javafire/JavaTestMojo.java
+++ b/javafire/src/main/java/io/github/olib963/javatest/javafire/JavaTestMojo.java
@@ -26,7 +26,7 @@ public class JavaTestMojo extends AbstractMojo {
 
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
-		var testRunner = new JavaTestRunner(Optional.ofNullable(testRunners), new ThreadLocalClassLoaderProvider(), lookupProject());
+		var testRunner = new JavaTestRunner(Optional.ofNullable(testRunners), Optional.empty(), new ThreadLocalClassLoaderProvider(), lookupProject());
 		validateResult(testRunner.run());
 	}
 

--- a/javafire/src/main/java/io/github/olib963/javatest/javafire/JavaTestRunner.java
+++ b/javafire/src/main/java/io/github/olib963/javatest/javafire/JavaTestRunner.java
@@ -4,16 +4,13 @@ import io.github.olib963.javatest.reflection.ReflectionRunners;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.project.MavenProject;
 import io.github.olib963.javatest.JavaTest;
-import io.github.olib963.javatest.TestRunners;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 class JavaTestRunner {
     private final Optional<String> testRunners;

--- a/javafire/src/main/java/io/github/olib963/javatest/javafire/JavaTestRunner.java
+++ b/javafire/src/main/java/io/github/olib963/javatest/javafire/JavaTestRunner.java
@@ -65,26 +65,26 @@ class JavaTestRunner {
         }
     }
 
-    private Class<?> loadClass(ClassLoader loader, String testRunners) {
+    private Class<?> loadClass(ClassLoader loader, String classToLoad) {
         try {
-            return loader.loadClass(testRunners);
+            return loader.loadClass(classToLoad);
         } catch (ClassNotFoundException e) {
             throw new InternalTestException(Status.EXECUTION_FAILURE,
-                    "Could not load the  given class (" + testRunners + ")", e);
+                    "Could not load the  given class (" + classToLoad + ")", e);
         }
     }
 
-    private <T> T instantiateAs(Class<?> runnersClass, Class<T> toInstantiateAs) {
+    private <T> T instantiateAs(Class<?> classToInstantiate, Class<T> toInstantiateAs) {
         try {
-            if (!toInstantiateAs.isAssignableFrom(runnersClass)) {
+            if (!toInstantiateAs.isAssignableFrom(classToInstantiate)) {
                 throw new InternalTestException(Status.FAILURE,
-                        "Given class (" + runnersClass.getName() + ") does not implement TestRunners");
+                        "Given class (" + classToInstantiate.getName() + ") does not implement " + toInstantiateAs.getName());
             }
-            return toInstantiateAs.cast(runnersClass.getConstructor(null).newInstance());
+            return toInstantiateAs.cast(classToInstantiate.getConstructor(null).newInstance());
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException
                 | NoSuchMethodException e) {
             throw new InternalTestException(Status.FAILURE,
-                    "Given class (" + runnersClass.getName() + ") could not be instantiated", e);
+                    "Given class (" + classToInstantiate.getName() + ") could not be instantiated", e);
         }
     }
 

--- a/javafire/src/test/java/io/github/olib963/javatest/javafire/JavaTestRunnerTest.java
+++ b/javafire/src/test/java/io/github/olib963/javatest/javafire/JavaTestRunnerTest.java
@@ -107,8 +107,7 @@ public class JavaTestRunnerTest implements TestSuiteClass {
         @Override
         public Collection<TestRunner> runners() {
             return List.of(JavaTest.testableRunner(
-                    List.of(test("Failure", () -> that(false, "Expected false"))),
-                    Collections.emptyList()
+                    List.of(test("Failure", () -> that(false, "Expected false")))
             ));
         }
     }
@@ -116,8 +115,7 @@ public class JavaTestRunnerTest implements TestSuiteClass {
         @Override
         public Collection<TestRunner> runners() {
             return List.of(JavaTest.testableRunner(
-                    List.of(test("Success", () -> that(true, "Expected true"))),
-                    Collections.emptyList()
+                    List.of(test("Success", () -> that(true, "Expected true")))
             ));
         }
     }

--- a/javatest/javatest-benchmark/src/main/java/io/github/olib963/javatest/benchmark/internal/BenchmarkRunner.java
+++ b/javatest/javatest-benchmark/src/main/java/io/github/olib963/javatest/benchmark/internal/BenchmarkRunner.java
@@ -1,5 +1,6 @@
 package io.github.olib963.javatest.benchmark.internal;
 
+import io.github.olib963.javatest.RunConfiguration;
 import io.github.olib963.javatest.TestResults;
 import io.github.olib963.javatest.TestRunner;
 
@@ -22,9 +23,9 @@ public class BenchmarkRunner implements TestRunner {
     }
 
     @Override
-    public TestResults run() {
+    public TestResults run(RunConfiguration configuration) {
         var startMillis = startMillisSupplier.get();
-        var results = runners.map(TestRunner::run).reduce(TestResults.empty(), TestResults::combine);
+        var results = runners.map(r -> r.run(configuration)).reduce(TestResults.empty(), TestResults::combine);
         var timeTaken = timerFunction.apply(startMillis);
         return results.addLog("Test run took " + formatter.apply(timeTaken));
     }

--- a/javatest/javatest-benchmark/src/test/java/io/github/olib963/javatest/benchmark/BenchmarkingTests.java
+++ b/javatest/javatest-benchmark/src/test/java/io/github/olib963/javatest/benchmark/BenchmarkingTests.java
@@ -47,9 +47,9 @@ public class BenchmarkingTests implements TestSuiteClass {
                     return that(result.holds, "Assertion should pass when test runs within limit");
                 }),
                 test("Runner adds log", () -> {
-                    TestRunner mockRunner = TestResults::empty;
+                    TestRunner mockRunner = c -> TestResults.empty();
                     var benchmarked = new BenchmarkRunner(Stream.of(mockRunner), Benchmark.DEFAULT_FORMAT, () -> 0L, t -> Duration.ofMillis(987654321));
-                    var results = benchmarked.run();
+                    var results = benchmarked.run(RunConfiguration.empty());
                     return that(results.allLogs().collect(Collectors.toList()), contains("Test run took 987654s 321ms"));
                 })
         );

--- a/javatest/javatest-benchmark/src/test/java/io/github/olib963/javatest/benchmark/DocumentationRunners.java
+++ b/javatest/javatest-benchmark/src/test/java/io/github/olib963/javatest/benchmark/DocumentationRunners.java
@@ -1,7 +1,7 @@
 package io.github.olib963.javatest.benchmark;
 
 import io.github.olib963.javatest.TestRunner;
-import io.github.olib963.javatest.TestRunners;
+import io.github.olib963.javatest.javafire.TestRunners;
 
 import java.util.Collection;
 import java.util.List;

--- a/javatest/javatest-core/docs/README.adoc
+++ b/javatest/javatest-core/docs/README.adoc
@@ -21,8 +21,8 @@ therefore JavaTest only introduces a few new functions and types to the language
 * Instead of being *Annotation* and *Exception* driven, JavaTest is *Function* and *Value* driven,
 lending itself to composability of tests and assertions.
 
-* JavaTests contains no reflection magic. A more declarative approach to testing is taken where setting up and customising tests is left
-to the writer.
+* JavaTests contains no reflection magic by default. A more declarative approach to testing is taken where setting up and
+customising tests is up to the writer.
 
 * A test should ideally only test one thing and should certainly test _at least_ one thing. Since
 all tests must return an assertion value the compiler will enforce that all tests only test one result.
@@ -203,7 +203,7 @@ include::../src/test/java/io/github/olib963/javatest/documentation/ClassAsSuite.
 
 ==== Suite Nesting
 
-``TestSuite``s contain ``Testable``s not ``Test``s and thus can even be contain other ``TestSuite``s.
+``TestSuite``s contain ``Testable``s not ``Test``s and thus can contain other ``TestSuite``s.
 
 [source, java]
 ----
@@ -226,7 +226,7 @@ include::../src/test/java/io/github/olib963/javatest/documentation/MyPendingTest
 The main `TestRunner` included in the core is created from a `Collection<Testable>`. You can optionally add a collection of
 ``TestCompletionObserver``s to the runner, by default a logging observer is passed that logs each test result with a colour
 corresponding to the state of the test (green for passing, red for failing and yellow for pending). If you want to turn off
-logging just pass an empty collection, a `TestCompletionObserver.plainLogger` also exists that uses no colours.
+logging just pass an empty collection. A `TestCompletionObserver.plainLogger` also exists that uses no colours.
 
 [source, java]
 ----

--- a/javatest/javatest-core/docs/README.adoc
+++ b/javatest/javatest-core/docs/README.adoc
@@ -138,6 +138,8 @@ toc::[]
 ** `TestSuite`: a named logical collection of ``Testable``s
 * `Assertion`: represents the expected state at the end of a test
 * `TestResults`: represents the combined result of your tests
+* `RunConfiguration`: An object that contains configuration for a specific run of JavaTest. Currently this just contains
+side-effecting observers.
 
 === Creating Assertions
 
@@ -223,10 +225,7 @@ include::../src/test/java/io/github/olib963/javatest/documentation/MyPendingTest
 
 === Test Runners
 
-The main `TestRunner` included in the core is created from a `Collection<Testable>`. You can optionally add a collection of
-``TestCompletionObserver``s to the runner, by default a logging observer is passed that logs each test result with a colour
-corresponding to the state of the test (green for passing, red for failing and yellow for pending). If you want to turn off
-logging just pass an empty collection. A `TestCompletionObserver.plainLogger` also exists that uses no colours.
+The main `TestRunner` included in the core is created from a `Collection<Testable>`.
 
 [source, java]
 ----
@@ -236,13 +235,11 @@ include::../src/test/java/io/github/olib963/javatest/documentation/RunnerDocumen
 include::../src/test/java/io/github/olib963/javatest/documentation/RunnerDocumentation.java[tags=normal, indent=-]
 ----
 
-Other `TestRunner` implementations are available in the other modules.
-
 ==== Laziness
 
-It is possible to create a lazy test runner from a `Stream<Testable>` also with optional collection of ``TestCompletionObserver``s.
-This runner however is not referentially transparent or reusable so must be used with care. This might be useful if you have
-a very large collection of tests and you want to lazily instantiate the different suites.
+It is possible to create a lazy test runner from a `Stream<Testable>`. This runner however is not referentially transparent
+or reusable so must be used with care. This might be useful if you have a very large collection of tests and you want
+to lazily instantiate the different suites.
 
 [source, java]
 ----
@@ -250,6 +247,20 @@ include::../src/test/java/io/github/olib963/javatest/documentation/RunnerDocumen
 include::../src/test/java/io/github/olib963/javatest/documentation/RunnerDocumentation.java[tags=imports]
 
 include::../src/test/java/io/github/olib963/javatest/documentation/RunnerDocumentation.java[tags=lazy, indent=-]
+----
+
+Other `TestRunner` implementations are available in the other modules.
+
+=== Run Configuration
+
+You can optionally add a collection of ``TestCompletionObserver``s and ``TestRunCompletionObserver``s to the run of JavaTest.
+By default a logging observer is passed that logs each test result with a colour corresponding to the state of the test
+(green for passing, red for failing and yellow for pending) and a logging observer for the completion of the run that logs
+the total failed, passing and pending results.
+
+[source, java]
+----
+include::../src/test/java/io/github/olib963/javatest/documentation/RunConfigurations.java[tags=include]
 ----
 
 === Core library maven dependency
@@ -268,19 +279,13 @@ include::../src/test/java/io/github/olib963/javatest/documentation/RunnerDocumen
 
 === In Java
 
-To run JavaTest simply pass your `TestRunner` instances to the `JavaTest.run()` function and handle the
-result how you see fit. There is a convenience function `runTests` defined to just run a `Collection<Testable>` using the default `CollectionRunner`:
+To run JavaTest simply pass your `TestRunner` instances to the `JavaTest.run()` function and handle the result how you see fit.
+There is a convenience function `runTests` defined to just run a `Collection<Testable>` using the default `CollectionRunner`:
 
 [source, java]
 ----
 include::../src/test/java/io/github/olib963/javatest/documentation/MyEntrypoint.java[tags=include]
 ----
-
-==== Observer
-
-There is an interface `TestRunCompletionObserver` that exists to allow side effects to be invoked after the run has completed.
-By default the total counts of tests run will be logged to `System.out`. If you want to turn off logging simply pass an empty
-collection of observers to the `run` function i.e. `JavaTest.run(runners, Collections.emptyList())`.
 
 === With JavaFire Maven plugin
 

--- a/javatest/javatest-core/docs/README.adoc
+++ b/javatest/javatest-core/docs/README.adoc
@@ -344,6 +344,27 @@ In `pom.xml`:
 
 You can override the `testRunners` class being used by setting the maven property e.g. `mvn -Djavafire.testRunners=com.my.app.OtherTests test`.
 
+==== Run Configuration
+
+You can provide your own `RunConfiguration` class within the plugin configuration. If you create a class with a *public zero argument constructor*
+that implements `RunConfigurationProvider` such as:
+
+[source, java]
+----
+include::../src/test/java/my/awesome/app/MyConfigProvider.java[]
+----
+
+then you can set the configuration option in the plugin:
+
+[source, xml]
+----
+ <configuration>
+    <runConfigurationProvider>my.awesome.app.MyConfigProvider</runConfigurationProvider>
+</configuration>
+----
+
+You can also override the provider class on the commandline by setting the maven property e.g. `mvn -Djavafire.runConfigurationProvider=com.my.app.ConfigProvider test`.
+
 === JShell
 
 Since JavaTest is built on pure Java it plays quite nicely with the REPL. This startup script may be useful to you:

--- a/javatest/javatest-core/src/main/java/io/github/olib963/javatest/JavaTest.java
+++ b/javatest/javatest-core/src/main/java/io/github/olib963/javatest/JavaTest.java
@@ -18,7 +18,7 @@ public class JavaTest {
     }
 
     public static TestResults run(Collection<TestRunner> runners, RunConfiguration config) {
-        var results = runners.stream().map(TestRunner::run).reduce(TestResults.empty(), TestResults::combine);
+        var results = runners.stream().map(r -> r.run(config)).reduce(TestResults.empty(), TestResults::combine);
         config.runObservers().forEach(o -> o.onRunCompletion(results));
         return results;
     }

--- a/javatest/javatest-core/src/main/java/io/github/olib963/javatest/JavaTest.java
+++ b/javatest/javatest-core/src/main/java/io/github/olib963/javatest/JavaTest.java
@@ -13,16 +13,13 @@ public class JavaTest {
     private JavaTest() {}
 
     // Main entry point of the library
-    private static final Collection<TestRunCompletionObserver> DEFAULT_RUN_OBSERVER =
-            Collections.singletonList(TestRunCompletionObserver.logger());
-
     public static TestResults run(Collection<TestRunner> runners) {
-        return run(runners, DEFAULT_RUN_OBSERVER);
+        return run(runners, RunConfiguration.defaultConfig());
     }
 
-    public static TestResults run(Collection<TestRunner> runners, Collection<TestRunCompletionObserver> observers) {
+    public static TestResults run(Collection<TestRunner> runners, RunConfiguration config) {
         var results = runners.stream().map(TestRunner::run).reduce(TestResults.empty(), TestResults::combine);
-        observers.forEach(o -> o.onRunCompletion(results));
+        config.runObservers().forEach(o -> o.onRunCompletion(results));
         return results;
     }
 
@@ -49,27 +46,16 @@ public class JavaTest {
     }
 
     // Stream Runner factory methods
-    private static final Collection<TestCompletionObserver> DEFAULT_OBSERVER =
-            Collections.singletonList(TestCompletionObserver.colourLogger());
-
     public static TestRunner testableRunner(Testable testable) {
         return testableRunner(List.of(testable));
     }
 
     public static TestRunner testableRunner(Collection<? extends Testable> tests) {
-        return testableRunner(tests, DEFAULT_OBSERVER);
-    }
-
-    public static TestRunner testableRunner(Collection<? extends Testable> tests, Collection<TestCompletionObserver> observers) {
-        return new CollectionRunner(tests, observers);
+        return new CollectionRunner(tests);
     }
 
     public static TestRunner lazyTestableRunner(Stream<? extends Testable> tests) {
-        return lazyTestableRunner(tests, DEFAULT_OBSERVER);
-    }
-
-    public static TestRunner lazyTestableRunner(Stream<? extends Testable> tests, Collection<TestCompletionObserver> observers) {
-        return new StreamRunner(tests, observers);
+        return new StreamRunner(tests);
     }
 
     // Test factory methods

--- a/javatest/javatest-core/src/main/java/io/github/olib963/javatest/RunConfiguration.java
+++ b/javatest/javatest-core/src/main/java/io/github/olib963/javatest/RunConfiguration.java
@@ -1,0 +1,57 @@
+package io.github.olib963.javatest;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+public class RunConfiguration {
+
+    private final Collection<TestCompletionObserver> testObservers;
+    private final Collection<TestRunCompletionObserver> runObservers;
+
+    private RunConfiguration(Collection<TestCompletionObserver> testObservers, Collection<TestRunCompletionObserver> runObservers) {
+        this.testObservers = testObservers;
+        this.runObservers = runObservers;
+    }
+
+    public static RunConfiguration defaultConfig() {
+        return new RunConfiguration(
+                Collections.singletonList(TestCompletionObserver.colourLogger()),
+                Collections.singletonList(TestRunCompletionObserver.logger())
+        );
+    }
+
+    public static RunConfiguration empty() {
+        return new RunConfiguration(Collections.emptyList(), Collections.emptyList());
+    }
+
+    public Stream<TestCompletionObserver> testObservers() {
+        return testObservers.stream();
+    }
+
+    public Stream<TestRunCompletionObserver> runObservers() {
+        return runObservers.stream();
+    }
+
+    public RunConfiguration addTestObserver(TestCompletionObserver observer) {
+                return addTestObservers(Collections.singletonList(observer));
+    }
+
+    public RunConfiguration addTestObservers(Collection<TestCompletionObserver> observers) {
+        var copy = new ArrayList<>(testObservers);
+        copy.addAll(observers);
+        return new RunConfiguration(copy, runObservers);
+    }
+
+    public RunConfiguration addRunObserver(TestRunCompletionObserver observer) {
+        return addRunObservers(Collections.singletonList(observer));
+    }
+
+    public RunConfiguration addRunObservers(Collection<TestRunCompletionObserver> observers) {
+        var copy = new ArrayList<>(runObservers);
+        copy.addAll(observers);
+        return new RunConfiguration(testObservers, copy);
+    }
+
+}

--- a/javatest/javatest-core/src/main/java/io/github/olib963/javatest/RunConfiguration.java
+++ b/javatest/javatest-core/src/main/java/io/github/olib963/javatest/RunConfiguration.java
@@ -7,6 +7,8 @@ import java.util.stream.Stream;
 
 public class RunConfiguration {
 
+    private static final RunConfiguration EMPTY_CONFIG = new RunConfiguration(Collections.emptyList(), Collections.emptyList());
+
     private final Collection<TestCompletionObserver> testObservers;
     private final Collection<TestRunCompletionObserver> runObservers;
 
@@ -23,7 +25,7 @@ public class RunConfiguration {
     }
 
     public static RunConfiguration empty() {
-        return new RunConfiguration(Collections.emptyList(), Collections.emptyList());
+        return EMPTY_CONFIG;
     }
 
     public Stream<TestCompletionObserver> testObservers() {
@@ -35,7 +37,7 @@ public class RunConfiguration {
     }
 
     public RunConfiguration addTestObserver(TestCompletionObserver observer) {
-                return addTestObservers(Collections.singletonList(observer));
+        return addTestObservers(Collections.singletonList(observer));
     }
 
     public RunConfiguration addTestObservers(Collection<TestCompletionObserver> observers) {

--- a/javatest/javatest-core/src/main/java/io/github/olib963/javatest/TestCompletionObserver.java
+++ b/javatest/javatest-core/src/main/java/io/github/olib963/javatest/TestCompletionObserver.java
@@ -2,6 +2,8 @@ package io.github.olib963.javatest;
 
 import io.github.olib963.javatest.logging.TestLoggingObserver;
 
+import java.io.PrintStream;
+
 @FunctionalInterface
 public interface TestCompletionObserver {
 
@@ -13,5 +15,9 @@ public interface TestCompletionObserver {
 
     static TestCompletionObserver colourLogger() {
         return TestLoggingObserver.COLOUR;
+    }
+
+    static TestCompletionObserver logTo(boolean colour, PrintStream stream) {
+        return new TestLoggingObserver(colour, stream);
     }
 }

--- a/javatest/javatest-core/src/main/java/io/github/olib963/javatest/TestRunner.java
+++ b/javatest/javatest-core/src/main/java/io/github/olib963/javatest/TestRunner.java
@@ -2,5 +2,5 @@ package io.github.olib963.javatest;
 
 @FunctionalInterface
 public interface TestRunner {
-    TestResults run();
+    TestResults run(RunConfiguration configuration);
 }

--- a/javatest/javatest-core/src/main/java/io/github/olib963/javatest/javafire/RunConfigurationProvider.java
+++ b/javatest/javatest-core/src/main/java/io/github/olib963/javatest/javafire/RunConfigurationProvider.java
@@ -1,0 +1,9 @@
+package io.github.olib963.javatest.javafire;
+
+import io.github.olib963.javatest.RunConfiguration;
+
+public interface RunConfigurationProvider {
+
+    RunConfiguration config();
+
+}

--- a/javatest/javatest-core/src/main/java/io/github/olib963/javatest/javafire/TestRunners.java
+++ b/javatest/javatest-core/src/main/java/io/github/olib963/javatest/javafire/TestRunners.java
@@ -1,7 +1,10 @@
-package io.github.olib963.javatest;
+package io.github.olib963.javatest.javafire;
+
+import io.github.olib963.javatest.TestRunner;
 
 import java.util.Collection;
 
+// TODO move to javafire package
 // Interface used to run the maven plugin
 public interface TestRunners {
     Collection<TestRunner> runners();

--- a/javatest/javatest-core/src/main/java/io/github/olib963/javatest/javafire/package-info.java
+++ b/javatest/javatest-core/src/main/java/io/github/olib963/javatest/javafire/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains interfaces used to interact with the JavaFire maven plugin
+ */
+package io.github.olib963.javatest.javafire;

--- a/javatest/javatest-core/src/main/java/io/github/olib963/javatest/runners/CollectionRunner.java
+++ b/javatest/javatest-core/src/main/java/io/github/olib963/javatest/runners/CollectionRunner.java
@@ -1,5 +1,6 @@
 package io.github.olib963.javatest.runners;
 
+import io.github.olib963.javatest.RunConfiguration;
 import io.github.olib963.javatest.TestResults;
 import io.github.olib963.javatest.TestRunner;
 import io.github.olib963.javatest.Testable;
@@ -14,7 +15,7 @@ public class CollectionRunner implements TestRunner {
     }
 
     @Override
-    public TestResults run() {
-        return new StreamRunner(testables.stream()).run();
+    public TestResults run(RunConfiguration configuration) {
+        return new StreamRunner(testables.stream()).run(configuration);
     }
 }

--- a/javatest/javatest-core/src/main/java/io/github/olib963/javatest/runners/CollectionRunner.java
+++ b/javatest/javatest-core/src/main/java/io/github/olib963/javatest/runners/CollectionRunner.java
@@ -1,6 +1,5 @@
 package io.github.olib963.javatest.runners;
 
-import io.github.olib963.javatest.TestCompletionObserver;
 import io.github.olib963.javatest.TestResults;
 import io.github.olib963.javatest.TestRunner;
 import io.github.olib963.javatest.Testable;
@@ -9,15 +8,13 @@ import java.util.Collection;
 
 public class CollectionRunner implements TestRunner {
     private final Collection<? extends Testable> testables;
-    private final Collection<TestCompletionObserver> observers;
 
-    public CollectionRunner(Collection<? extends Testable> testables, Collection<TestCompletionObserver> observers) {
+    public CollectionRunner(Collection<? extends Testable> testables) {
         this.testables = testables;
-        this.observers = observers;
     }
 
     @Override
     public TestResults run() {
-        return new StreamRunner(testables.stream(), observers).run();
+        return new StreamRunner(testables.stream()).run();
     }
 }

--- a/javatest/javatest-core/src/main/java/io/github/olib963/javatest/runners/StreamRunner.java
+++ b/javatest/javatest-core/src/main/java/io/github/olib963/javatest/runners/StreamRunner.java
@@ -15,23 +15,22 @@ public class StreamRunner implements TestRunner {
     }
 
     @Override
-    public TestResults run() {
+    public TestResults run(RunConfiguration configuration) {
         return tests
-                .map(this::runTestable)
+                .map(t -> runTestable(t, configuration))
                 .reduce(TestResults.empty(), TestResults::addResult, TestResults::combine);
     }
 
-    private TestResult runTestable(Testable testable) {
+    private TestResult runTestable(Testable testable, RunConfiguration configuration) {
         return testable.match(
                 suite -> {
                     var result = runSuite(suite);
-                    // TODO observers from config
-//                    observers.forEach(o -> o.onTestCompletion(result));
+                    configuration.testObservers().forEach(o -> o.onTestCompletion(result));
                     return result;
                 },
                 test -> {
                     var result = runTest(test);
-//                    observers.forEach(o -> o.onTestCompletion(result));
+                    configuration.testObservers().forEach(o -> o.onTestCompletion(result));
                     return result;
                 }
         );

--- a/javatest/javatest-core/src/main/java/io/github/olib963/javatest/runners/StreamRunner.java
+++ b/javatest/javatest-core/src/main/java/io/github/olib963/javatest/runners/StreamRunner.java
@@ -9,11 +9,9 @@ import java.util.stream.Stream;
 
 public class StreamRunner implements TestRunner {
     private final Stream<? extends Testable> tests;
-    private final Collection<TestCompletionObserver> observers;
 
-    public StreamRunner(Stream<? extends Testable> tests, Collection<TestCompletionObserver> observers) {
+    public StreamRunner(Stream<? extends Testable> tests) {
         this.tests = tests;
-        this.observers = observers;
     }
 
     @Override
@@ -27,12 +25,13 @@ public class StreamRunner implements TestRunner {
         return testable.match(
                 suite -> {
                     var result = runSuite(suite);
-                    observers.forEach(o -> o.onTestCompletion(result));
+                    // TODO observers from config
+//                    observers.forEach(o -> o.onTestCompletion(result));
                     return result;
                 },
                 test -> {
                     var result = runTest(test);
-                    observers.forEach(o -> o.onTestCompletion(result));
+//                    observers.forEach(o -> o.onTestCompletion(result));
                     return result;
                 }
         );

--- a/javatest/javatest-core/src/main/java/module-info.java
+++ b/javatest/javatest-core/src/main/java/module-info.java
@@ -1,3 +1,4 @@
 module javatest.core {
     exports io.github.olib963.javatest;
+    exports io.github.olib963.javatest.javafire;
 }

--- a/javatest/javatest-core/src/test/java/io/github/olib963/javatest/AllTests.java
+++ b/javatest/javatest-core/src/test/java/io/github/olib963/javatest/AllTests.java
@@ -14,7 +14,7 @@ public class AllTests {
         var simpleTests = SimpleTests.passing();
         var failingTests = suite("Failing Tests", SimpleTests.FAILING.map(t ->
                 test(t.name, () -> {
-                    var results = run(List.of(testableRunner(t)), Collections.emptyList());
+                    var results = run(List.of(testableRunner(t)), RunConfiguration.empty());
                     return that(!results.succeeded, t.name + " should fail");
                 })).collect(Collectors.toList()));
         var loggingTests = new LoggingTests();
@@ -32,7 +32,7 @@ public class AllTests {
                 SuiteOfSuites.compositeSuite(),
                 new MyPendingTests()
         ));
-        var docResult = run(List.of(simpleDocRunner, extraDocRunners.singleTestRunner, extraDocRunners.suiteTestsNoLogging, lazyDocRunners.lazyRunner));
+        var docResult = run(List.of(simpleDocRunner, extraDocRunners.singleTestRunner, extraDocRunners.suiteTests, lazyDocRunners.lazyRunner));
         if (!docResult.succeeded) {
             throw new RuntimeException("Documentation tests failed!");
         }

--- a/javatest/javatest-core/src/test/java/io/github/olib963/javatest/documentation/MyEntrypoint.java
+++ b/javatest/javatest-core/src/test/java/io/github/olib963/javatest/documentation/MyEntrypoint.java
@@ -28,7 +28,7 @@ public class MyEntrypoint {
 class MyCustomRunner implements TestRunner {
 
     @Override
-    public TestResults run() {
+    public TestResults run(RunConfiguration configuration) {
         return TestResults.empty();
     }
 }

--- a/javatest/javatest-core/src/test/java/io/github/olib963/javatest/documentation/RunConfigurations.java
+++ b/javatest/javatest-core/src/test/java/io/github/olib963/javatest/documentation/RunConfigurations.java
@@ -1,0 +1,22 @@
+package io.github.olib963.javatest.documentation;
+
+// tag::include[]
+import io.github.olib963.javatest.RunConfiguration;
+import io.github.olib963.javatest.TestCompletionObserver;
+
+public class RunConfigurations {
+
+    // Configuration that logs individual tests in colour and the full results of the run
+    public RunConfiguration defaultConfig = RunConfiguration.defaultConfig();
+
+    // Configuration that logs individual tests with no colour and logs a warning
+    // if there are any pending tests at all in the run.
+    public RunConfiguration customConfig = RunConfiguration.empty()
+            .addTestObserver(TestCompletionObserver.plainLogger())
+            .addRunObserver(results -> {
+                if (results.pendingCount != 0) {
+                    System.err.println("!!You still have unwritten tests!!");
+                }
+            });
+}
+// end::include[]

--- a/javatest/javatest-core/src/test/java/io/github/olib963/javatest/documentation/RunnerDocumentation.java
+++ b/javatest/javatest-core/src/test/java/io/github/olib963/javatest/documentation/RunnerDocumentation.java
@@ -22,9 +22,8 @@ public class RunnerDocumentation {
         public TestRunner singleTestRunner = testableRunner(List.of(
                 test("Simple test", () -> pending())));
 
-        public TestRunner suiteTestsNoLogging = testableRunner(
-                List.of(MyFirstTestSuite.mySuite(), new ClassAsSuite()),
-                Collections.emptyList() // No observers so no logging
+        public TestRunner suiteTests = testableRunner(
+                List.of(MyFirstTestSuite.mySuite(), new ClassAsSuite())
         );
     }
     // end::normal[]

--- a/javatest/javatest-core/src/test/java/io/github/olib963/javatest/documentation/functions/FunctionalRunners.java
+++ b/javatest/javatest-core/src/test/java/io/github/olib963/javatest/documentation/functions/FunctionalRunners.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 public class FunctionalRunners {
     // The simplest test runner: runs nothing and returns no results
-    public static final TestRunner EMPTY_RUNNER = TestResults::empty;
+    public static final TestRunner EMPTY_RUNNER = config -> TestResults.empty();
 
     private static final Set<DayOfWeek> WEEKEND =
             Set.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY);
@@ -19,8 +19,8 @@ public class FunctionalRunners {
     // Wrap another test runner such that it will not run anything on the weekend
     public TestRunner onlyRunOnWeekDays(TestRunner runner) {
         var today = LocalDate.now();
-        return () -> WEEKEND.contains(today.getDayOfWeek()) ?
-                EMPTY_RUNNER.run() : runner.run();
+        return config -> WEEKEND.contains(today.getDayOfWeek()) ?
+                EMPTY_RUNNER.run(config) : runner.run(config);
     }
 }
 // end::include[]

--- a/javatest/javatest-core/src/test/java/my/awesome/app/MyConfigProvider.java
+++ b/javatest/javatest-core/src/test/java/my/awesome/app/MyConfigProvider.java
@@ -1,0 +1,33 @@
+package my.awesome.app;
+
+import io.github.olib963.javatest.RunConfiguration;
+import io.github.olib963.javatest.TestCompletionObserver;
+import io.github.olib963.javatest.TestResult;
+import io.github.olib963.javatest.TestRunCompletionObserver;
+import io.github.olib963.javatest.javafire.RunConfigurationProvider;
+
+/**
+ * My config provider only logs failed tests and the full run results
+ */
+public class MyConfigProvider implements RunConfigurationProvider {
+
+    @Override
+    public RunConfiguration config() {
+        var loggingObserver = TestCompletionObserver.colourLogger();
+        TestCompletionObserver onlyLogFailures = result -> {
+            if(testFailed(result)) {
+                loggingObserver.onTestCompletion(result);
+            }
+        };
+        return RunConfiguration.empty()
+                .addRunObserver(TestRunCompletionObserver.logger())
+                .addTestObserver(onlyLogFailures);
+    }
+
+    private boolean testFailed(TestResult result) {
+        return result.match(
+                suiteResult -> suiteResult.results().anyMatch(this::testFailed),
+                singleTestResult -> !singleTestResult.result.holds
+        );
+    }
+}

--- a/javatest/javatest-eventually/src/test/java/io/github/olib963/javatest/eventually/EventuallyTests.java
+++ b/javatest/javatest-eventually/src/test/java/io/github/olib963/javatest/eventually/EventuallyTests.java
@@ -23,7 +23,7 @@ public class EventuallyTests implements TestSuiteClass {
                 new PassingTests(),
                 suite("Failing Tests",  EventuallyTests.FAILING.map(t ->
                         test(t.name, () -> {
-                            var results = run(List.of(testableRunner(t)), Collections.emptyList());
+                            var results = run(List.of(testableRunner(t)), RunConfiguration.empty());
                             return that(!results.succeeded, t.name + " should fail");
                         })
                 ).collect(Collectors.toList()))

--- a/javatest/javatest-eventually/src/test/java/io/github/olib963/javatest/eventually/documentation/IntegrationTestRunners.java
+++ b/javatest/javatest-eventually/src/test/java/io/github/olib963/javatest/eventually/documentation/IntegrationTestRunners.java
@@ -1,7 +1,7 @@
 package io.github.olib963.javatest.eventually.documentation;
 
 import io.github.olib963.javatest.TestRunner;
-import io.github.olib963.javatest.TestRunners;
+import io.github.olib963.javatest.javafire.TestRunners;
 import io.github.olib963.javatest.eventually.InitialDelayTests;
 import io.github.olib963.javatest.fixtures.FixtureDefinition;
 import io.github.olib963.javatest.fixtures.Fixtures;

--- a/javatest/javatest-fixtures/src/main/java/io/github/olib963/javatest/fixtures/internal/FixtureRunner.java
+++ b/javatest/javatest-fixtures/src/main/java/io/github/olib963/javatest/fixtures/internal/FixtureRunner.java
@@ -1,5 +1,6 @@
 package io.github.olib963.javatest.fixtures.internal;
 
+import io.github.olib963.javatest.RunConfiguration;
 import io.github.olib963.javatest.TestResults;
 import io.github.olib963.javatest.TestRunner;
 import io.github.olib963.javatest.fixtures.FixtureDefinition;
@@ -20,16 +21,16 @@ public class FixtureRunner<Fixture> implements TestRunner {
     }
 
     @Override
-    public TestResults run() {
+    public TestResults run(RunConfiguration configuration) {
         return fixtureDefinition.create()
                 .mapError(e -> new Exception("Could not create fixture \"" + fixtureName + '"', e))
-                .map(this::runWithFixture)
+                .map(f -> runWithFixture(f, configuration))
                 .recoverWith(e -> TestResults.empty().failBecause(flattenMessages(e)));
 
     }
 
-    private TestResults runWithFixture(Fixture fixture) {
-        var results = testFunction.apply(fixture).run();
+    private TestResults runWithFixture(Fixture fixture, RunConfiguration configuration) {
+        var results = testFunction.apply(fixture).run(configuration);
         return fixtureDefinition.destroy(fixture)
                 .map(unit -> results)
                 .recoverWith(e -> results.failBecause(

--- a/javatest/javatest-fixtures/src/test/java/io/github/olib963/javatest/fixtures/documentation/MyRunners.java
+++ b/javatest/javatest-fixtures/src/test/java/io/github/olib963/javatest/fixtures/documentation/MyRunners.java
@@ -3,6 +3,7 @@ package io.github.olib963.javatest.fixtures.documentation;
 // tag::include[]
 import io.github.olib963.javatest.*;
 import io.github.olib963.javatest.fixtures.Fixtures;
+import io.github.olib963.javatest.javafire.TestRunners;
 
 import java.util.Collection;
 import java.util.List;

--- a/javatest/javatest-junit/src/main/java/io/github/olib963/javatest/junit/JUnitTestRunner.java
+++ b/javatest/javatest-junit/src/main/java/io/github/olib963/javatest/junit/JUnitTestRunner.java
@@ -1,5 +1,6 @@
 package io.github.olib963.javatest.junit;
 
+import io.github.olib963.javatest.RunConfiguration;
 import io.github.olib963.javatest.TestResults;
 import io.github.olib963.javatest.TestRunner;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
@@ -18,7 +19,7 @@ public final class JUnitTestRunner implements TestRunner {
     }
 
     @Override
-    public TestResults run() {
+    public TestResults run(RunConfiguration configuration) {
         var launcher = LauncherFactory.create();
         var listener = new SummaryGeneratingListener();
         launcher.registerTestExecutionListeners(listener);

--- a/javatest/javatest-junit/src/test/java/io/github/olib963/javatest/junit/AllTests.java
+++ b/javatest/javatest-junit/src/test/java/io/github/olib963/javatest/junit/AllTests.java
@@ -2,7 +2,7 @@ package io.github.olib963.javatest.junit;
 
 import io.github.olib963.javatest.JavaTest;
 import io.github.olib963.javatest.TestRunner;
-import io.github.olib963.javatest.TestRunners;
+import io.github.olib963.javatest.javafire.TestRunners;
 import io.github.olib963.javatest.junit.documentation.JUnitRunners;
 
 import java.util.ArrayList;

--- a/javatest/javatest-junit/src/test/java/io/github/olib963/javatest/junit/Tests.java
+++ b/javatest/javatest-junit/src/test/java/io/github/olib963/javatest/junit/Tests.java
@@ -2,7 +2,7 @@ package io.github.olib963.javatest.junit;
 
 import io.github.olib963.javatest.JavaTest;
 import io.github.olib963.javatest.TestRunner;
-import io.github.olib963.javatest.TestRunners;
+import io.github.olib963.javatest.javafire.TestRunners;
 import io.github.olib963.javatest.junit.documentation.JUnitRunners;
 
 import java.util.ArrayList;

--- a/javatest/javatest-matchers/src/test/java/io/github/olib963/javatest/matchers/Utils.java
+++ b/javatest/javatest-matchers/src/test/java/io/github/olib963/javatest/matchers/Utils.java
@@ -1,5 +1,6 @@
 package io.github.olib963.javatest.matchers;
 
+import io.github.olib963.javatest.RunConfiguration;
 import io.github.olib963.javatest.Testable.*;
 
 import java.util.Collections;
@@ -16,7 +17,7 @@ public class Utils {
                 suite("Passing Tests", passingTests.collect(Collectors.toList())),
                 suite("Failing Tests", failingTests.map(t ->
                     test(t.name, () -> {
-                        var results = run(List.of(testableRunner(t)), Collections.emptyList());
+                        var results = run(List.of(testableRunner(t)), RunConfiguration.empty());
                         return that(!results.succeeded, t.name + " should fail");
                     })).collect(Collectors.toList()))
         ));

--- a/javatest/javatest-reflection/src/main/java/io/github/olib963/javatest/reflection/ReflectionRunners.java
+++ b/javatest/javatest-reflection/src/main/java/io/github/olib963/javatest/reflection/ReflectionRunners.java
@@ -56,7 +56,7 @@ public class ReflectionRunners implements TestRunners {
         var suiteRunner = testableRunner(aggregated.suites);
 
         // If there were any failures loading/creating the classes create a failed result.
-        TestRunner failingRunner = () -> aggregated.classFailures.stream()
+        TestRunner failingRunner = config -> aggregated.classFailures.stream()
                 .reduce(TestResults.empty(), TestResults::failBecause, TestResults::combine);
 
         return Stream.concat(

--- a/javatest/javatest-reflection/src/main/java/io/github/olib963/javatest/reflection/ReflectionRunners.java
+++ b/javatest/javatest-reflection/src/main/java/io/github/olib963/javatest/reflection/ReflectionRunners.java
@@ -2,7 +2,7 @@ package io.github.olib963.javatest.reflection;
 
 import io.github.olib963.javatest.TestResults;
 import io.github.olib963.javatest.TestRunner;
-import io.github.olib963.javatest.TestRunners;
+import io.github.olib963.javatest.javafire.TestRunners;
 import io.github.olib963.javatest.TestSuiteClass;
 import io.github.olib963.javatest.reflection.internal.Aggregate;
 import io.github.olib963.javatest.reflection.internal.Utils;

--- a/javatest/javatest-reflection/src/main/java/io/github/olib963/javatest/reflection/internal/Aggregate.java
+++ b/javatest/javatest-reflection/src/main/java/io/github/olib963/javatest/reflection/internal/Aggregate.java
@@ -1,6 +1,6 @@
 package io.github.olib963.javatest.reflection.internal;
 
-import io.github.olib963.javatest.TestRunners;
+import io.github.olib963.javatest.javafire.TestRunners;
 import io.github.olib963.javatest.TestSuiteClass;
 
 import java.util.ArrayList;

--- a/javatest/javatest-reflection/src/test/java/failing/FailToInstantiateRunners.java
+++ b/javatest/javatest-reflection/src/test/java/failing/FailToInstantiateRunners.java
@@ -1,7 +1,7 @@
 package failing;
 
 import io.github.olib963.javatest.TestRunner;
-import io.github.olib963.javatest.TestRunners;
+import io.github.olib963.javatest.javafire.TestRunners;
 
 import java.util.Collection;
 import java.util.List;

--- a/javatest/javatest-reflection/src/test/java/io/github/olib963/javatest/reflection/runners/FailingRunners.java
+++ b/javatest/javatest-reflection/src/test/java/io/github/olib963/javatest/reflection/runners/FailingRunners.java
@@ -2,7 +2,7 @@ package io.github.olib963.javatest.reflection.runners;
 
 import io.github.olib963.javatest.JavaTest;
 import io.github.olib963.javatest.TestRunner;
-import io.github.olib963.javatest.TestRunners;
+import io.github.olib963.javatest.javafire.TestRunners;
 import io.github.olib963.javatest.fixtures.FixtureDefinition;
 import io.github.olib963.javatest.fixtures.Try;
 

--- a/javatest/javatest-reflection/src/test/java/io/github/olib963/javatest/reflection/runners/InvalidRunners.java
+++ b/javatest/javatest-reflection/src/test/java/io/github/olib963/javatest/reflection/runners/InvalidRunners.java
@@ -1,7 +1,7 @@
 package io.github.olib963.javatest.reflection.runners;
 
 import io.github.olib963.javatest.TestRunner;
-import io.github.olib963.javatest.TestRunners;
+import io.github.olib963.javatest.javafire.TestRunners;
 
 import java.util.Collection;
 

--- a/javatest/javatest-reflection/src/test/java/io/github/olib963/javatest/reflection/runners/Runners.java
+++ b/javatest/javatest-reflection/src/test/java/io/github/olib963/javatest/reflection/runners/Runners.java
@@ -2,7 +2,7 @@ package io.github.olib963.javatest.reflection.runners;
 
 import io.github.olib963.javatest.JavaTest;
 import io.github.olib963.javatest.TestRunner;
-import io.github.olib963.javatest.TestRunners;
+import io.github.olib963.javatest.javafire.TestRunners;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/scala/README.adoc
+++ b/scala/README.adoc
@@ -77,8 +77,7 @@ object MySuite extends Suite with JavaTestSyntax {
 
 === Test Runners
 
-An implicit transformation exists to turn a `Seq[Testable]` into a `TestRunner`. Alternatively you can customise the test
-runner by overriding the default test observer.
+An implicit transformation exists to turn a `Seq[Testable]` into a `TestRunner`.
 
 [source, scala]
 ----
@@ -98,19 +97,18 @@ run(
     )
   )
 )
+----
 
-// Custom Runner
-  // TODO separate documentation for run configuration
-//  val customRunner = testableRunner(
-//    Seq(
-//      suite("My Suite",
-//        test("test1")(that(true, "passes")),
-//        test("test2")(that(true, "passes"))
-//      )
-//    ),
-//    // Observer function: (TestResult => Unit)
-//    result => println(result)
-//  )
+==== Run Configuration
+
+You can provide your own `RunConfiguration` if you want to provide your own side-effecting observers to run as tests are completed
+
+[source, scala]
+----
+run(
+  Seq(test("test1")(that(true, "passes")): TestRunner),
+  RunConfiguration.empty().addRunObserver((results: TestResults) => if(results.pendingCount > 0) println("Tests still need to be written"))
+)
 ----
 
 == Matchers
@@ -376,9 +374,10 @@ object MyTests {
         FixtureDocumentation.runner1,
         FixtureDocumentation.runner2,
         BenchmarkDocumentation,
-        SuiteDocs
+        SuiteDocs,
+        RunnerDocs.runner
       ) ++ MyRunners.Runners
-    )
+    ).combine(RunnerDocs.runDirectly()).combine(RunnerDocs.runWithCustomConfig())
 
     if (!documentationResults.succeeded) {
       sys.error("Documentation tests failed")

--- a/scala/README.adoc
+++ b/scala/README.adoc
@@ -100,16 +100,17 @@ run(
 )
 
 // Custom Runner
-val customRunner = testableRunner(
-  Seq(
-    suite("My Suite",
-      test("test1")(that(true, "passes")),
-      test("test2")(that(true, "passes"))
-    )
-  ),
-  // Observer function: (TestResult => Unit)
-  result => println(result)
-)
+  // TODO separate documentation for run configuration
+//  val customRunner = testableRunner(
+//    Seq(
+//      suite("My Suite",
+//        test("test1")(that(true, "passes")),
+//        test("test2")(that(true, "passes"))
+//      )
+//    ),
+//    // Observer function: (TestResult => Unit)
+//    result => println(result)
+//  )
 ----
 
 == Matchers

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -33,7 +33,8 @@ val CommonSettings = Seq(
   licenses := List("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt")),
   homepage := Some(url("https://github.com/olib963/javatest/scala")),
   publishTo := sonatypePublishToBundle.value,
-  resolvers += Resolver.sonatypeRepo("snapshots")
+  resolvers += Resolver.sonatypeRepo("snapshots"),
+  scalacOptions ++= scalaVersionSpecificOptions(scalaVersion.value),
 ) ++ SettingsForAllProjects
 
 def scalaVersionSpecificOptions(version: String): Option[String] =
@@ -57,7 +58,6 @@ val core = (project in file("core"))
       organisationName % "javatest-fixtures" % javaTestVersion,
       organisationName % "javatest-matchers" % javaTestVersion
     ),
-    scalacOptions ++= scalaVersionSpecificOptions(scalaVersion.value),
     description := "Scala wrapper around JavaTest framework"
   )
 

--- a/scala/core/src/main/scala-2.11/io/github/olib963/javatest_scala/FunctionConverters.scala
+++ b/scala/core/src/main/scala-2.11/io/github/olib963/javatest_scala/FunctionConverters.scala
@@ -1,6 +1,6 @@
 package io.github.olib963.javatest_scala
 
-import io.github.olib963.javatest.{CheckedSupplier, TestCompletionObserver, TestResult}
+import io.github.olib963.javatest.{CheckedSupplier, TestCompletionObserver, TestResult, TestResults, TestRunCompletionObserver}
 
 import scala.concurrent.duration.Duration
 import scala.language.implicitConversions
@@ -27,6 +27,10 @@ private [javatest_scala] object FunctionConverters {
 
   implicit def scalaFunctionToTestCompletionObserver(f: TestResult => Unit): TestCompletionObserver = new TestCompletionObserver {
     override def onTestCompletion(result: TestResult): Unit = f(result)
+  }
+
+  implicit def scalaFunctionToRunCompletionObserver(f: TestResults => Unit): TestRunCompletionObserver = new TestRunCompletionObserver {
+    override def onRunCompletion(result: TestResults): Unit = f(result)
   }
 
   implicit def scalaFunctionToCheckedSupplier[A](s: () => A): CheckedSupplier[A] = new CheckedSupplier[A] {

--- a/scala/core/src/main/scala/io/github/olib963/javatest_scala/JavaTestSyntax.scala
+++ b/scala/core/src/main/scala/io/github/olib963/javatest_scala/JavaTestSyntax.scala
@@ -11,6 +11,7 @@ trait JavaTestSyntax {
 
   def run(firstRunner: TestRunner, runners: TestRunner*): TestResults = run(firstRunner :: runners.toList)
   def run(runners: Seq[TestRunner]): TestResults = JavaTest.run(toJava(runners))
+  def run(runners: Seq[TestRunner], runConfiguration: RunConfiguration): TestResults = JavaTest.run(toJava(runners), runConfiguration)
 
   def suite(name: String, firstTest: Testable, tests: Testable*): Testable.TestSuite = suite(name, firstTest +: tests.toSeq)
   def suite(name: String, tests: Seq[Testable]): Testable.TestSuite = JavaTest.suite(name, toJava(tests))
@@ -27,10 +28,6 @@ trait JavaTestSyntax {
   def all(assertions: Seq[Assertion]): Assertion = JavaTest.all(toJava(assertions))
 
   implicit def runnerFromTestable(testable: Testable): TestRunner = JavaTest.testableRunner(testable)
-  implicit def runnerFromTestables(testables: Seq[Testable]): TestRunner = JavaTest.testableRunner(toJava((testables)))
-  def testableRunner(testables: Seq[Testable], observers: (TestResult => Unit)*): TestRunner = {
-    val asJavaObservers = observers.map(f => ((result: TestResult) => f(result)): TestCompletionObserver)
-    JavaTest.testableRunner(toJava(testables), toJava(asJavaObservers))
-  }
+  implicit def runnerFromTestables(testables: Seq[Testable]): TestRunner = JavaTest.testableRunner(toJava(testables))
 
 }

--- a/scala/core/src/main/scala/io/github/olib963/javatest_scala/Runners.scala
+++ b/scala/core/src/main/scala/io/github/olib963/javatest_scala/Runners.scala
@@ -2,7 +2,8 @@ package io.github.olib963.javatest_scala
 
 import java.util
 
-import io.github.olib963.javatest.{TestRunner, TestRunners}
+import io.github.olib963.javatest.TestRunner
+import io.github.olib963.javatest.javafire.TestRunners
 import CollectionConverters._
 
 trait Runners extends TestRunners {

--- a/scala/core/src/test/scala/io/github/olib963/javatest_scala/MyTests.scala
+++ b/scala/core/src/test/scala/io/github/olib963/javatest_scala/MyTests.scala
@@ -30,9 +30,10 @@ object MyTests {
         FixtureDocumentation.runner1,
         FixtureDocumentation.runner2,
         BenchmarkDocumentation,
-        SuiteDocs
+        SuiteDocs,
+        RunnerDocs.runner
       ) ++ MyRunners.Runners
-    )
+    ).combine(RunnerDocs.runDirectly()).combine(RunnerDocs.runWithCustomConfig())
 
     if (!documentationResults.succeeded) {
       sys.error("Documentation tests failed")

--- a/scala/core/src/test/scala/io/github/olib963/javatest_scala/documentation/RunnerDocs.scala
+++ b/scala/core/src/test/scala/io/github/olib963/javatest_scala/documentation/RunnerDocs.scala
@@ -28,16 +28,17 @@ object RunnerDocs extends JavaTestSyntax {
   }
 
   // tag::customDefinition[]
-  val customRunner = testableRunner(
-    Seq(
-      suite("My Suite",
-        test("test1")(that(true, "passes")),
-        test("test2")(that(true, "passes"))
-      )
-    ),
-    // Observer function: (TestResult => Unit)
-    result => println(result)
-  )
+  // TODO separate documentation for run configuration
+//  val customRunner = testableRunner(
+//    Seq(
+//      suite("My Suite",
+//        test("test1")(that(true, "passes")),
+//        test("test2")(that(true, "passes"))
+//      )
+//    ),
+//    // Observer function: (TestResult => Unit)
+//    result => println(result)
+//  )
   // end::customDefinition[]
 
 }

--- a/scala/core/src/test/scala/io/github/olib963/javatest_scala/documentation/RunnerDocs.scala
+++ b/scala/core/src/test/scala/io/github/olib963/javatest_scala/documentation/RunnerDocs.scala
@@ -1,7 +1,9 @@
 package io.github.olib963.javatest_scala.documentation
 
-import io.github.olib963.javatest.TestRunner
+import io.github.olib963.javatest.{RunConfiguration, TestResults, TestRunner}
 import io.github.olib963.javatest_scala.JavaTestSyntax
+
+import io.github.olib963.javatest_scala.FunctionConverters._
 
 object RunnerDocs extends JavaTestSyntax {
 
@@ -14,7 +16,7 @@ object RunnerDocs extends JavaTestSyntax {
   )
   // end::definition[]
 
-  def runThem(): Unit = {
+  def runDirectly() =
     // tag::running[]
     run(
       Seq(
@@ -25,20 +27,13 @@ object RunnerDocs extends JavaTestSyntax {
       )
     )
     // end::running[]
-  }
 
-  // tag::customDefinition[]
-  // TODO separate documentation for run configuration
-//  val customRunner = testableRunner(
-//    Seq(
-//      suite("My Suite",
-//        test("test1")(that(true, "passes")),
-//        test("test2")(that(true, "passes"))
-//      )
-//    ),
-//    // Observer function: (TestResult => Unit)
-//    result => println(result)
-//  )
-  // end::customDefinition[]
+  def runWithCustomConfig() =
+  // tag::customConfig[]
+    run(
+      Seq(test("test1")(that(true, "passes")): TestRunner),
+      RunConfiguration.empty().addRunObserver((results: TestResults) => if(results.pendingCount > 0) println("Tests still need to be written"))
+    )
+  // end::customConfig[]
 
 }

--- a/scala/docs/README.adoc
+++ b/scala/docs/README.adoc
@@ -48,8 +48,7 @@ include::../core/src/test/scala/io/github/olib963/javatest_scala/documentation/S
 
 === Test Runners
 
-An implicit transformation exists to turn a `Seq[Testable]` into a `TestRunner`. Alternatively you can customise the test
-runner by overriding the default test observer.
+An implicit transformation exists to turn a `Seq[Testable]` into a `TestRunner`.
 
 [source, scala]
 ----
@@ -57,9 +56,15 @@ include::../core/src/test/scala/io/github/olib963/javatest_scala/documentation/R
 
 // Or to run directly
 include::../core/src/test/scala/io/github/olib963/javatest_scala/documentation/RunnerDocs.scala[tags=running, indent=-]
+----
 
-// Custom Runner
-include::../core/src/test/scala/io/github/olib963/javatest_scala/documentation/RunnerDocs.scala[tags=customDefinition, indent=-]
+==== Run Configuration
+
+You can provide your own `RunConfiguration` if you want to provide your own side-effecting observers to run as tests are completed
+
+[source, scala]
+----
+include::../core/src/test/scala/io/github/olib963/javatest_scala/documentation/RunnerDocs.scala[tags=customConfig, indent=-]
 ----
 
 == Matchers

--- a/scala/sbt-interface/src/main/scala-2.11/io/github/olib963/javatest_sbt_interface/FunctionConverters.scala
+++ b/scala/sbt-interface/src/main/scala-2.11/io/github/olib963/javatest_sbt_interface/FunctionConverters.scala
@@ -1,6 +1,6 @@
 package io.github.olib963.javatest_sbt_interface
 
-import io.github.olib963.javatest.{TestRunCompletionObserver, TestResults}
+import io.github.olib963.javatest.{TestCompletionObserver, TestResult, TestResults, TestRunCompletionObserver}
 
 import scala.language.implicitConversions
 import java.util.function._
@@ -12,8 +12,20 @@ private [javatest_sbt_interface] object FunctionConverters {
     override def apply(a1: A, a2: A): A = f(a1, a2)
   }
 
+  implicit def scalaFunctionToTestCompletionObserver(f: TestResult => Unit): TestCompletionObserver = new TestCompletionObserver {
+    override def onTestCompletion(result: TestResult): Unit = f(result)
+  }
+
   implicit def scalaFunctionToTestRunCompletionObserver(f: TestResults => Unit): TestRunCompletionObserver = new TestRunCompletionObserver {
     override def onRunCompletion(results: TestResults): Unit = f(results)
+  }
+
+  implicit def scalaFunctionToJavaFunction[A, B](f: A => B): Function[A, B] = new Function[A, B] {
+    override def apply(a: A): B = f(a)
+  }
+
+  implicit def scalaFunctionToJavaPredicate[A](f: A => Boolean): Predicate[A] = new Predicate[A] {
+    override def test(a: A): Boolean = f(a)
   }
 
 }

--- a/scala/sbt-interface/src/main/scala/io/github/olib963/javatest_sbt_interface/JavaTestRunner.scala
+++ b/scala/sbt-interface/src/main/scala/io/github/olib963/javatest_sbt_interface/JavaTestRunner.scala
@@ -1,0 +1,41 @@
+package io.github.olib963.javatest_sbt_interface
+
+import java.util.concurrent.atomic.AtomicReference
+import java.util.stream.Collectors
+
+import io.github.olib963.javatest.TestResults
+import io.github.olib963.javatest_scala.{Runners, Suite}
+import sbt.testing.{Runner, Task, TaskDef}
+
+import scala.util.Try
+
+class JavaTestRunner(val args: Array[String], val remoteArgs: Array[String], val testClassLoader: ClassLoader) extends Runner {
+  val allResults = new AtomicReference(TestResults.empty())
+
+  override def done(): String = {
+    val results = allResults.get()
+    val logs = CollectionConverters.toScala(results.allLogs().collect(Collectors.toList[String]))
+    val totals =
+      s"""Ran a total of ${results.testCount()} tests.
+         |${results.successCount} succeeded
+         |${results.failureCount} failed
+         |${results.pendingCount} pending
+         |""".stripMargin
+    if (logs.isEmpty) totals else totals + "\n" + logs.mkString("\n")
+  }
+
+  override def tasks(taskDefs: Array[TaskDef]): Array[Task] =
+    taskDefs.collect {
+      case taskDef if taskDef.fingerprint() == JavaTestScalaFramework.SuiteFingerprint =>
+        new JavaTestTask(moduleOf[Suite](taskDef).map(Seq(_)), taskDef, allResults)
+      case taskDef if taskDef.fingerprint() == JavaTestScalaFramework.RunnerFingerprint =>
+        new JavaTestTask(moduleOf[Runners](taskDef).map(_.Runners), taskDef, allResults)
+    }
+
+  private def moduleOf[A](task: TaskDef): Try[A] = Try {
+    testClassLoader.loadClass(s"${task.fullyQualifiedName()}$$")
+      .getDeclaredField("MODULE$")
+      .get(null)
+      .asInstanceOf[A]
+  }
+}

--- a/scala/sbt-interface/src/main/scala/io/github/olib963/javatest_sbt_interface/JavaTestScalaFramework.scala
+++ b/scala/sbt-interface/src/main/scala/io/github/olib963/javatest_sbt_interface/JavaTestScalaFramework.scala
@@ -1,15 +1,7 @@
 package io.github.olib963.javatest_sbt_interface
 
-import java.io.{OutputStream, PrintStream}
-import java.util.concurrent.atomic.AtomicReference
-import java.util.stream.Collectors
-
-import io.github.olib963.javatest.{JavaTest, RunConfiguration, TestCompletionObserver, TestResults, TestRunCompletionObserver, TestRunner}
 import io.github.olib963.javatest_scala.{Runners, Suite}
-import sbt.testing.{Event, EventHandler, Fingerprint, Framework, Logger, OptionalThrowable, Runner, Selector, Status, SubclassFingerprint, Task, TaskDef}
-
-import scala.reflect.ClassTag
-import scala.util.{Failure, Success, Try}
+import sbt.testing.{Fingerprint, Framework, Runner}
 
 class JavaTestScalaFramework extends Framework {
   override def name(): String = "JavaTest-Scala"
@@ -20,121 +12,10 @@ class JavaTestScalaFramework extends Framework {
   )
 
   override def runner(args: Array[String], remoteArgs: Array[String], testClassLoader: ClassLoader): Runner =
-    JavaTestRunner(args, remoteArgs, testClassLoader)
+    new JavaTestRunner(args, remoteArgs, testClassLoader)
 }
 
 object JavaTestScalaFramework {
-
-  class ScalaFingerPrint[A](implicit classTag: ClassTag[A]) extends SubclassFingerprint {
-    override def isModule: Boolean = true
-
-    override def requireNoArgConstructor(): Boolean = true
-
-    override def superclassName(): String = classTag.runtimeClass.getName
-
-    override def equals(obj: Any): Boolean = obj match {
-      case classBased: SubclassFingerprint =>
-        classBased.isModule && classBased.requireNoArgConstructor() && classBased.superclassName() == this.superclassName()
-      case _ => false
-    }
-
-    override def toString: String = s"Fingerprint for ${superclassName()}"
-  }
-
-  val SuiteFingerprint = new ScalaFingerPrint[Suite]
-  val RunnerFingerprint = new ScalaFingerPrint[Runners]
-}
-
-case class JavaTestRunner(args: Array[String], remoteArgs: Array[String], testClassLoader: ClassLoader) extends Runner {
-  val allResults = new AtomicReference(TestResults.empty())
-
-  override def done(): String = {
-    val results = allResults.get()
-    val logs = CollectionConverters.toScala(results.allLogs().collect(Collectors.toList[String]))
-    val totals =
-      s"""Ran a total of ${results.testCount()} tests.
-         |${results.successCount} succeeded
-         |${results.failureCount} failed
-         |${results.pendingCount} pending
-         |""".stripMargin
-    if (logs.isEmpty) totals else totals + "\n" + logs.mkString("\n")
-  }
-
-  override def tasks(taskDefs: Array[TaskDef]): Array[Task] =
-    taskDefs.collect {
-      case t if t.fingerprint() == JavaTestScalaFramework.SuiteFingerprint =>
-        JavaTestTask(moduleOf[Suite](t).map(Seq(_)), t, allResults)
-      case t if t.fingerprint() == JavaTestScalaFramework.RunnerFingerprint =>
-        JavaTestTask(moduleOf[Runners](t).map(_.Runners), t, allResults)
-    }
-
-  private def moduleOf[A](task: TaskDef): Try[A] = Try {
-    testClassLoader.loadClass(s"${task.fullyQualifiedName()}$$").getDeclaredField("MODULE$").get(null).asInstanceOf[A]
-  }
-}
-
-case class JavaTestTask(toRun: Try[Seq[TestRunner]], taskDef: TaskDef, totalResults: AtomicReference[TestResults]) extends Task {
-  override def tags(): Array[String] = Array()
-  import FunctionConverters._
-
-  override def execute(eventHandler: EventHandler, loggers: Array[Logger]): Array[Task] = {
-    // TODO pass run config in
-    val runConfig = RunConfiguration.empty()
-      .addTestObservers(CollectionConverters.toJava(logResults(loggers)))
-      .addRunObserver(addToTotal)
-      .addRunObserver(triggerEvent(eventHandler))
-    toRun match {
-      case Success(runners) =>
-        JavaTest.run(CollectionConverters.toJava(runners), CollectionConverters.toJava(List(addToTotal, triggerEvent(eventHandler))))
-      case Failure(error) =>
-        eventHandler.handle(createEvent(Status.Error, error = Some(error)))
-    }
-    Array()
-  }
-
-  // The results of each run are added on to the total so that the "done()" message contains the total
-  private val addToTotal: TestRunCompletionObserver = (results: TestResults) => {
-    totalResults.getAndAccumulate(results, (r1: TestResults, r2: TestResults) => r1 combine r2)
-    ()
-  }
-
-  private def logResults(loggers: Array[Logger]): Seq[TestCompletionObserver] = loggers.map(logger =>
-    TestCompletionObserver.logTo(logger.ansiCodesSupported(), new LogInfoStream(logger))
-  ).toList
-
-  // TODO what is the better abstraction? Should we create a JavaTest Logger?
-  private class LogInfoStream(logger: Logger) extends PrintStream(OutputStream.nullOutputStream(), true) {
-    private var internalBuffer: String = ""
-    override def print(s: String): Unit = {
-      internalBuffer = internalBuffer + s
-    }
-
-    override def println(x: String): Unit = {
-      logger.info(internalBuffer + x)
-      internalBuffer = ""
-    }
-  }
-
-  // An event is triggered by each test result to inform sbt of failures & successes
-  def triggerEvent(eventHandler: EventHandler): TestRunCompletionObserver = (results: TestResults) => {
-    val status =
-      if (!results.succeeded)
-        Status.Failure
-      else if (results.pendingCount > 0)
-        Status.Pending
-      else
-        Status.Success
-    eventHandler.handle(createEvent(status))
-  }
-
-  // TODO do we need an event per test???? Or per suite :/
-  private def createEvent(eventStatus: Status, error: Option[Throwable] = None): Event = new Event {
-    override def fullyQualifiedName(): String = taskDef.fullyQualifiedName()
-    override def fingerprint(): Fingerprint = taskDef.fingerprint()
-    override def selector(): Selector = taskDef.selectors().head // TODO what if the number of selectors != 1?
-    override def status(): Status = eventStatus
-    override def throwable(): OptionalThrowable = error.fold(new OptionalThrowable())(new OptionalThrowable(_))
-    override def duration(): Long = -1
-  }
-
+  val SuiteFingerprint = new ScalaModuleFingerPrint[Suite]
+  val RunnerFingerprint = new ScalaModuleFingerPrint[Runners]
 }

--- a/scala/sbt-interface/src/main/scala/io/github/olib963/javatest_sbt_interface/JavaTestScalaFramework.scala
+++ b/scala/sbt-interface/src/main/scala/io/github/olib963/javatest_sbt_interface/JavaTestScalaFramework.scala
@@ -1,9 +1,10 @@
 package io.github.olib963.javatest_sbt_interface
 
+import java.io.{OutputStream, PrintStream}
 import java.util.concurrent.atomic.AtomicReference
 import java.util.stream.Collectors
 
-import io.github.olib963.javatest.{JavaTest, TestResults, TestRunCompletionObserver, TestRunner}
+import io.github.olib963.javatest.{JavaTest, TestCompletionObserver, TestResults, TestRunCompletionObserver, TestRunner}
 import io.github.olib963.javatest_scala.{Runners, Suite}
 import sbt.testing.{Event, EventHandler, Fingerprint, Framework, Logger, OptionalThrowable, Runner, Selector, Status, SubclassFingerprint, Task, TaskDef}
 
@@ -62,9 +63,9 @@ case class JavaTestRunner(args: Array[String], remoteArgs: Array[String], testCl
   override def tasks(taskDefs: Array[TaskDef]): Array[Task] =
     taskDefs.collect {
       case t if t.fingerprint() == JavaTestScalaFramework.SuiteFingerprint =>
-        JavaTestTask(moduleOf[Suite](t).map(List(_)), t, allResults)
+        JavaTestTask(moduleOf[Suite](t).map(Left(_)), t, allResults)
       case t if t.fingerprint() == JavaTestScalaFramework.RunnerFingerprint =>
-        JavaTestTask(moduleOf[Runners](t).map(_.Runners), t, allResults)
+        JavaTestTask(moduleOf[Runners](t).map(t => Right(t.Runners)), t, allResults)
     }
 
   private def moduleOf[A](task: TaskDef): Try[A] = Try {
@@ -72,25 +73,49 @@ case class JavaTestRunner(args: Array[String], remoteArgs: Array[String], testCl
   }
 }
 
-case class JavaTestTask(toRun: Try[Seq[TestRunner]], taskDef: TaskDef, totalResults: AtomicReference[TestResults]) extends Task {
+case class JavaTestTask(toRun: Try[Either[Suite, Seq[TestRunner]]], taskDef: TaskDef, totalResults: AtomicReference[TestResults]) extends Task {
   override def tags(): Array[String] = Array()
   import FunctionConverters._
 
-  // TODO how do we use the loggers? are they needed? We could hook them in as observers?
   override def execute(eventHandler: EventHandler, loggers: Array[Logger]): Array[Task] = {
     toRun match {
-      case Success(runners) =>
-        JavaTest.run(CollectionConverters.toJava(runners), CollectionConverters.toJava(List(addToTotal, triggerEvent(eventHandler))))
+      case Success(Left(suite)) =>
+        // TODO should all observers be passed in to the run function?
+        val runner = JavaTest.testableRunner(CollectionConverters.toJava(Seq(suite)), CollectionConverters.toJava(logResults(loggers)))
+        run(Seq(runner), eventHandler)
+      case Success(Right(runners)) =>
+        // TODO test observers aren't here.
+        run(runners, eventHandler)
       case Failure(error) =>
         eventHandler.handle(createEvent(Status.Error, error = Some(error)))
     }
     Array()
   }
 
+  private def run(runners: Seq[TestRunner], eventHandler: EventHandler): Unit =
+    JavaTest.run(CollectionConverters.toJava(runners), CollectionConverters.toJava(List(addToTotal, triggerEvent(eventHandler))))
+
   // The results of each run are added on to the total so that the "done()" message contains the total
   private def addToTotal: TestRunCompletionObserver = (results: TestResults) => {
     totalResults.getAndAccumulate(results, (r1: TestResults, r2: TestResults) => r1 combine r2)
     ()
+  }
+
+  private def logResults(loggers: Array[Logger]): Seq[TestCompletionObserver] = loggers.map(logger =>
+    TestCompletionObserver.logTo(logger.ansiCodesSupported(), new LogInfoStream(logger))
+  ).toList
+
+  // TODO what is the better abstraction? Should we create a JavaTest Logger?
+  private class LogInfoStream(logger: Logger) extends PrintStream(OutputStream.nullOutputStream(), true) {
+    private var internalBuffer: String = ""
+    override def print(s: String): Unit = {
+      internalBuffer = internalBuffer + s
+    }
+
+    override def println(x: String): Unit = {
+      logger.info(internalBuffer + x)
+      internalBuffer = ""
+    }
   }
 
   // An event is triggered by each test result to inform sbt of failures & successes

--- a/scala/sbt-interface/src/main/scala/io/github/olib963/javatest_sbt_interface/JavaTestTask.scala
+++ b/scala/sbt-interface/src/main/scala/io/github/olib963/javatest_sbt_interface/JavaTestTask.scala
@@ -4,6 +4,7 @@ import java.io.{OutputStream, PrintStream}
 import java.util.concurrent.atomic.AtomicReference
 
 import io.github.olib963.javatest._
+import io.github.olib963.javatest_scala.run
 import sbt.testing._
 
 import scala.util.{Failure, Success, Try}
@@ -22,10 +23,8 @@ class JavaTestTask(val toRun: Try[Seq[TestRunner]], val taskDef: TaskDef, val to
       .addRunObserver(addToTotal)
       .addRunObserver(triggerEvent(eventHandler))
     toRun match {
-      case Success(runners) =>
-        JavaTest.run(CollectionConverters.toJava(runners), CollectionConverters.toJava(List(addToTotal, triggerEvent(eventHandler))))
-      case Failure(error) =>
-        eventHandler.handle(TestEvent(taskDef, Status.Error, error))
+      case Success(runners) => run(runners, runConfig)
+      case Failure(error) => eventHandler.handle(TestEvent(taskDef, Status.Error, error))
     }
     Array()
   }
@@ -36,6 +35,7 @@ class JavaTestTask(val toRun: Try[Seq[TestRunner]], val taskDef: TaskDef, val to
     ()
   }
 
+  // TODO log failures as error
   private def logResults(loggers: Array[Logger]): Seq[TestCompletionObserver] = loggers.map(logger =>
     TestCompletionObserver.logTo(logger.ansiCodesSupported(), new LogInfoStream(logger))
   ).toList

--- a/scala/sbt-interface/src/main/scala/io/github/olib963/javatest_sbt_interface/JavaTestTask.scala
+++ b/scala/sbt-interface/src/main/scala/io/github/olib963/javatest_sbt_interface/JavaTestTask.scala
@@ -1,0 +1,68 @@
+package io.github.olib963.javatest_sbt_interface
+
+import java.io.{OutputStream, PrintStream}
+import java.util.concurrent.atomic.AtomicReference
+
+import io.github.olib963.javatest._
+import sbt.testing._
+
+import scala.util.{Failure, Success, Try}
+
+
+class JavaTestTask(val toRun: Try[Seq[TestRunner]], val taskDef: TaskDef, val totalResults: AtomicReference[TestResults]) extends Task {
+
+  override def tags(): Array[String] = Array()
+
+  import FunctionConverters._
+
+  override def execute(eventHandler: EventHandler, loggers: Array[Logger]): Array[Task] = {
+    // TODO pass run config in
+    val runConfig = RunConfiguration.empty()
+      .addTestObservers(CollectionConverters.toJava(logResults(loggers)))
+      .addRunObserver(addToTotal)
+      .addRunObserver(triggerEvent(eventHandler))
+    toRun match {
+      case Success(runners) =>
+        JavaTest.run(CollectionConverters.toJava(runners), CollectionConverters.toJava(List(addToTotal, triggerEvent(eventHandler))))
+      case Failure(error) =>
+        eventHandler.handle(TestEvent(taskDef, Status.Error, error))
+    }
+    Array()
+  }
+
+  // The results of each run are added on to the total so that the "done()" message contains the total
+  private val addToTotal: TestRunCompletionObserver = (results: TestResults) => {
+    totalResults.getAndAccumulate(results, (r1: TestResults, r2: TestResults) => r1 combine r2)
+    ()
+  }
+
+  private def logResults(loggers: Array[Logger]): Seq[TestCompletionObserver] = loggers.map(logger =>
+    TestCompletionObserver.logTo(logger.ansiCodesSupported(), new LogInfoStream(logger))
+  ).toList
+
+  // TODO what is the better abstraction? Should we create a JavaTest Logger?
+  private class LogInfoStream(logger: Logger) extends PrintStream(OutputStream.nullOutputStream(), true) {
+    private var internalBuffer: String = ""
+    override def print(s: String): Unit = {
+      internalBuffer = internalBuffer + s
+    }
+
+    override def println(x: String): Unit = {
+      logger.info(internalBuffer + x)
+      internalBuffer = ""
+    }
+  }
+
+  // An event is triggered by each test result to inform sbt of failures & successes
+  def triggerEvent(eventHandler: EventHandler): TestRunCompletionObserver = (results: TestResults) => {
+    val status =
+      if (!results.succeeded)
+        Status.Failure
+      else if (results.pendingCount > 0)
+        Status.Pending
+      else
+        Status.Success
+    eventHandler.handle(TestEvent(taskDef, status))
+  }
+
+}

--- a/scala/sbt-interface/src/main/scala/io/github/olib963/javatest_sbt_interface/ScalaModuleFingerPrint.scala
+++ b/scala/sbt-interface/src/main/scala/io/github/olib963/javatest_sbt_interface/ScalaModuleFingerPrint.scala
@@ -1,0 +1,18 @@
+package io.github.olib963.javatest_sbt_interface
+
+import sbt.testing.SubclassFingerprint
+
+import scala.reflect.ClassTag
+
+class ScalaModuleFingerPrint[A](implicit classTag: ClassTag[A]) extends SubclassFingerprint {
+  override def isModule: Boolean = true
+  override def requireNoArgConstructor(): Boolean = true
+  override def superclassName(): String = classTag.runtimeClass.getName
+  override def equals(obj: Any): Boolean = obj match {
+    case classBased: SubclassFingerprint =>
+      classBased.isModule && classBased.requireNoArgConstructor() && classBased.superclassName() == this.superclassName()
+    case _ => false
+  }
+
+  override def toString: String = s"Fingerprint for ${superclassName()}"
+}

--- a/scala/sbt-interface/src/main/scala/io/github/olib963/javatest_sbt_interface/TestEvent.scala
+++ b/scala/sbt-interface/src/main/scala/io/github/olib963/javatest_sbt_interface/TestEvent.scala
@@ -1,0 +1,17 @@
+package io.github.olib963.javatest_sbt_interface
+
+import sbt.testing._
+
+object TestEvent {
+  private def createEvent(taskDef: TaskDef, eventStatus: Status, error: Option[Throwable] = None): Event = new Event {
+    override def fullyQualifiedName(): String = taskDef.fullyQualifiedName()
+    override def fingerprint(): Fingerprint = taskDef.fingerprint()
+    override def selector(): Selector = taskDef.selectors().head // TODO what if the number of selectors != 1?
+    override def status(): Status = eventStatus
+    override def throwable(): OptionalThrowable = error.fold(new OptionalThrowable())(new OptionalThrowable(_))
+    override def duration(): Long = -1 // TODO do we want to add durations?
+  }
+
+  def apply(taskDef: TaskDef, eventStatus: Status): Event = createEvent(taskDef, eventStatus)
+  def apply(taskDef: TaskDef, eventStatus: Status, error: Throwable): Event = createEvent(taskDef, eventStatus, Some(error))
+}

--- a/scala/sbt-test/src/test/scala/my/app/ScalacheckSuite.scala
+++ b/scala/sbt-test/src/test/scala/my/app/ScalacheckSuite.scala
@@ -2,7 +2,7 @@ package my.app
 
 import io.github.olib963.javatest.Testable.Test
 import io.github.olib963.javatest.matchers.internal.PredicateMatcher
-import io.github.olib963.javatest.{JavaTest, TestResults, TestRunCompletionObserver, TestRunner, Testable}
+import io.github.olib963.javatest.{JavaTest, RunConfiguration, TestResults, TestRunCompletionObserver, TestRunner, Testable}
 // tag::imports[]
 import io.github.olib963.javatest_scala._
 import io.github.olib963.javatest_scala.scalacheck._
@@ -63,8 +63,7 @@ object ScalacheckSuite extends Suite {
   )
 
   // Hide the logging from failed tests
-  private def runTestNoLogging(test: Test) =
-    JavaTest.run(java.util.List.of[TestRunner](testableRunner(Seq(test))), java.util.Collections.emptyList[TestRunCompletionObserver])
+  private def runTestNoLogging(test: Test) = run(Seq(runnerFromTestable(test)), RunConfiguration.empty())
 
   // Scala 11 is bad with functional interfaces
   private val failed = PredicateMatcher.of(new java.util.function.Predicate[TestResults]{


### PR DESCRIPTION
Looking at implementing the SBT logger interface such that the test framework correctly logs when run through SBT.

This changes the interface for test observers fairly significantly in order to allow the SBT plugin to add its own observers.